### PR TITLE
Set a timeout for finish and login expect script.

### DIFF
--- a/bin/finish.expect
+++ b/bin/finish.expect
@@ -1,6 +1,6 @@
 #!/usr/local/bin/expect -f
 
-set timeout -1
+set timeout 3500
 
 spawn tail -n 0 -f "/var/consoles/$env(machine)"
 expect -re "CONGRATULATIONS! Your OpenBSD ....... has been successfully completed!"

--- a/bin/login.expect
+++ b/bin/login.expect
@@ -1,6 +1,6 @@
 #!/usr/local/bin/expect -f
 
-set timeout -1
+set timeout 3500
 
 spawn tail -n 0 -f "/var/consoles/$env(machine)"
 expect "login: "


### PR DESCRIPTION
Running scripts without timeout leads to stalled processes without
progress.  It is better to fail with error and try again.  Especially
jobs run by cron get a chance to recover this way.

Change the finish and login timeout from infinite to 3500 seconds.
This is a bit less than an hour as the console program prints a
mark every hour.  This log should not interrupt the timeout.