### PR TITLE
Improve "sucessfully locked" message

### DIFF
--- a/bin/lock.sh
+++ b/bin/lock.sh
@@ -9,7 +9,7 @@ fi
 
 if [ -z "$lock" ]; then
 	echo "$testuser" > /home/$USER/env/lock
-	echo "$machine is locked by $testuser"
+	echo "$machine locked"
 	exit 0
 fi
 


### PR DESCRIPTION
"$machine is locked" sounds like you cannot lock it because
someone else already locked it.  Removing the "is" makes it
clearer that we have just locked the machine.