### PR TITLE
Use timeout in expect scripts.

### DIFF
--- a/finish.expect
+++ b/finish.expect
@@ -1,9 +1,8 @@
 #!/usr/local/bin/expect -f
 
 set timeout 3500
-
 spawn tail -n 0 -f "/var/consoles/$env(machine)"
-expect -re "CONGRATULATIONS! Your OpenBSD ....... has been successfully completed!"
+expect timeout { exit 1 } -re "CONGRATULATIONS! Your OpenBSD ....... has been successfully completed!"
 #           CONGRATULATIONS! Your OpenBSD install has been successfully completed!
 #           CONGRATULATIONS! Your OpenBSD upgrade has been successfully completed!
 

--- a/login.expect
+++ b/login.expect
@@ -1,7 +1,5 @@
 #!/usr/local/bin/expect -f
 
 set timeout 3500
-
 spawn tail -n 0 -f "/var/consoles/$env(machine)"
-expect "login: "
-exit 0
+expect timeout { exit 1 } "login: " { exit 0 }


### PR DESCRIPTION
It is not enough to specify a timeout value.  The command exit 1
has to be given to expect to abort when a timeout occurs.