### PR TITLE
Wait 15 minutes for login, then send newline and check console log.

### DIFF
--- a/login.expect
+++ b/login.expect
@@ -1,5 +1,5 @@
 #!/usr/local/bin/expect -f
 
-set timeout 3500
+set timeout 900
 spawn tail -n 0 -f "/var/consoles/$env(machine)"
 expect timeout { exit 1 } "login: " { exit 0 }

--- a/reboot.sh
+++ b/reboot.sh
@@ -13,5 +13,6 @@ if ! login.expect; then
 	printf "\n\005c." | console -f $machine
 	sleep 1
 	printf "\n\005c." | console -f $machine
-	login.expect
+	sleep 1
+	tail -n 16 "/var/consoles/$machine" | grep '^login: '
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -237,4 +237,12 @@ if [ "$arch" = "sparc64" ]; then
 		printf "boot disk\n\005c." | console -f $machine
 	fi
 fi
-login.expect
+
+if ! login.expect; then
+	echo "no login prompt on machine $machine, send two newline"
+	printf "\n\005c." | console -f $machine
+	sleep 1
+	printf "\n\005c." | console -f $machine
+	sleep 1
+	tail -n 16 "/var/consoles/$machine" | grep '^login: '
+fi


### PR DESCRIPTION
Expecting login a second time did not work as the login prompt was already in the console log.  Better grep it immediately from the last lines of the log.  Also wait only 15 minutes for the first login prompt.  If it is triggered by a newline it must show up within a second.  Use the same logic in reboot and setup script.