### PR TITLE
Write a newline to console before expecting open firmware promt.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -222,6 +222,7 @@ if [ "$arch" = "sparc64" ]; then
 		fi
 		power.sh cycle
 		sleep 300
+		printf "\n\005c." | console -f $machine
 		ofwprompt.expect && break
 		false
 	done


### PR DESCRIPTION
The conserver writes marks into the console log.  After a sleep the
ok may he followed by a log file mark.  Then the regexp would not
match.  A newline before expecting makes this situation less likely.