### PR TITLE
only show content since last boot

### DIFF
--- a/info.sh
+++ b/info.sh
@@ -3,16 +3,21 @@
 set -eu
 
 dmesg=$(mktemp)
+dmesg_tmp=$(mktemp)
 sysctl=$(mktemp)
 ifconfig=$(mktemp)
 usbdevs=$(mktemp)
 pcidump=$(mktemp)
 
-ssh root@$machine 'cat /var/run/dmesg.boot' > $dmesg
+ssh root@$machine 'cat /var/run/dmesg.boot' > $dmesg_tmp
 ssh root@$machine sysctl > $sysctl
 ssh root@$machine ifconfig > $ifconfig
 ssh root@$machine 'usbdevs -vv' > $usbdevs
 ssh root@$machine 'pcidump -v' > $pcidump
+
+dmesg_start=$(grep -n ^OpenBSD $dmesg_tmp | tail -1 | grep -oE ^[0-9]+)
+dmesg_end=$(wc -l $dmesg_tmp | tr -d ' ' | grep -oE ^[0-9]+)
+tail -n $((dmesg_end - dmesg_start + 1)) $dmesg_tmp > $dmesg
 
 cat << EOF
 <!doctype html>
@@ -82,4 +87,4 @@ pre {
 </html>
 EOF
 
-rm $dmesg $sysctl $ifconfig $usbdevs $pcidump
+rm $dmesg_tmp $dmesg $sysctl $ifconfig $usbdevs $pcidump


### PR DESCRIPTION
Please test this first on all ot machines.

There might be a simpler way to do this but in my experiments using a single line and AWK, I could not include the ^OpenBSD line.