### PR TITLE
make sparc64 v440 setup more reliable

### DIFF
--- a/sparcpower.sh
+++ b/sparcpower.sh
@@ -11,16 +11,13 @@ if [ $# -ne 2 ]; then
 	usage
 fi
 
-echo blub
-echo blub
-
 port=$1
 action=$2
 
 case "$action" in
 "0")
 	echo "power off, machine $machine, send poweroff via lom"
-	printf "\n#.\npoweroff\nconsole\n\005c." | console -f $machine
+	printf "\n#.\npoweroff -y\nconsole\n\005c." | console -f $machine
 	;;
 "1")
 	echo "power on, machine $machine, send poweron via lom"


### PR DESCRIPTION
* reset and poweroff require -y otherwise "REALLY? [Y/n]" comes up.
* reset -c drops into console after the reset.
* timeout in case syncing the filesystem takes too long.
* sending "break" on the console seems to send a break but the ilom is still responsive afterwards for a short time, so I see no benefit for it on the v440.
* sleep while waiting for hardware checks to finish
* remove debug prints