### PR TITLE
add timeout similar to the reboot in setup

### DIFF
--- a/reboot.sh
+++ b/reboot.sh
@@ -6,7 +6,8 @@ PATH="/home/test/bin:$PATH"
 
 echo "reboot machine $machine"
 
-ssh root@${ipaddr} shutdown -r now reboot by testmaster || power.sh cycle
+timeout 60 ssh root@${ipaddr} shutdown -r now reboot by testmaster || \
+	power.sh cycle
 
 if ! login.expect; then
 	echo "no login prompt on machine $machine, send two newline"


### PR DESCRIPTION
ot5 currently is hanging because reboot hangs.
This might fix it, maybe not.

~We are currently not certain that timeout with ssh works.
Please do not merge this yet.~
Testmaster was out of sync with the repo.

It could still make sense to add this in case a reboot hangs due to the filesystem.