### PR TITLE
Revert "powerup does a console reopen 60 seconds after cycle"

### DIFF
--- a/powerup.sh
+++ b/powerup.sh
@@ -9,10 +9,6 @@ echo "power up machine $machine"
 if ! timeout 60 ssh root@${ipaddr} true; then
 	power.sh cycle
 
-	# bmc may shutdown console after power off, reopen after bmc activated
-	sleep 60
-	printf "\n\005co\005c." | console -f $machine
-
 	if ! login.expect; then
 		echo "no login prompt on machine $machine, send two newline"
 		printf "\n\005c." | console -f $machine


### PR DESCRIPTION
Reopen console during install does not work properly.  Forcing console up that is connected via ssh to remote console server leaves ssh sessions behind.  Then the console device is busy and cannot reattach.

This reverts commit 46da8458d536f28292b656d5779e7e86b763df32.