### PR TITLE
Allow semi automic install on vmm host.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -78,6 +78,7 @@ mk_setup_conf() {
 		Password for root = ${rootpw:-toor}
 		Public ssh key for root = ${sshkey:-}
 		Network interfaces = ${interface}
+		Network interface to configure = ${interface}
 		IPv4 address for ${interface} = ${ipaddr}
 		Default IPv4 route = 10.0.1.1
 		$(if [ -n "${userpw:-}" ]; then

--- a/vmm.sh
+++ b/vmm.sh
@@ -18,4 +18,4 @@ case "$action" in
 esac
 
 echo "vmm $command, machine ${machine} on ${vmhost}"
-ssh "${machine}@${vmhost}" "vmctl $command $machine"
+ssh "${machine}@${vmhost}" "vmctl $command $machine" || true


### PR DESCRIPTION
Remote install still needs some manual interaction at config of vmd host and console of vmm guest, but commands on testmaster continue until guest is installed with OpenBSD.